### PR TITLE
clear old interval before setting new one

### DIFF
--- a/lib/glasslab-sdk.js
+++ b/lib/glasslab-sdk.js
@@ -53,7 +53,7 @@ either expressed or implied, of the FreeBSD Project.
     // Queue for non-on-demand messages
     this._dispatchQueue = [];
     this._dispatchQueueReady = [];
-    setInterval( _flushDispatchQueue, this._options.dispatchQueueUpdateInterval );
+    this._flushDispatchQueueIntervalHandle = setInterval( _flushDispatchQueue, this._options.dispatchQueueUpdateInterval );
 
     // The following variables will undergo change as functions are performed with the SDK
     this._activeGameSessionId = "";
@@ -66,11 +66,11 @@ either expressed or implied, of the FreeBSD Project.
     // Is only activated when getPlayerInfo is successful
     // Deactivated on logout
     this._isAuthenticated = false;
-    setInterval( _sendTotalTimePlayed, this._options.sendTotalTimePlayedInterval );
+    this._sendTotalTimePlayedIntervalHandle = setInterval( _sendTotalTimePlayed, this._options.sendTotalTimePlayedInterval );
 
     // Update function for polling matches at certain intervals
     this._matches = {};
-    setInterval( _pollMatches, this._options.pollMatchesInterval );
+    this._pollMatchesIntervalHandle = setInterval( _pollMatches, this._options.pollMatchesInterval );
   }
 
   _GlassLabSDK.prototype.getOptions = function() {
@@ -113,17 +113,20 @@ either expressed or implied, of the FreeBSD Project.
 
       if( options.hasOwnProperty( 'dispatchQueueUpdateInterval' ) ) {
         this._options.dispatchQueueUpdateInterval = options.dispatchQueueUpdateInterval;
-        setInterval( _flushDispatchQueue, this._options.dispatchQueueUpdateInterval );
+        clearInterval(this._flushDispatchQueueIntervalHandle);
+        this._flushDispatchQueueIntervalHandle = setInterval( _flushDispatchQueue, this._options.dispatchQueueUpdateInterval );
       }
 
       if( options.hasOwnProperty( 'sendTotalTimePlayedInterval' ) ) {
         this._options.sendTotalTimePlayedInterval = options.sendTotalTimePlayedInterval;
-        setInterval( _sendTotalTimePlayed, this._options.sendTotalTimePlayedInterval );
+        clearInterval(this._sendTotalTimePlayedIntervalHandle);
+        this._sendTotalTimePlayedIntervalHandle = setInterval( _sendTotalTimePlayed, this._options.sendTotalTimePlayedInterval );
       }
 
       if( options.hasOwnProperty( 'pollMatchesInterval' ) ) {
         this._options.pollMatchesInterval = options.pollMatchesInterval;
-        setInterval( _pollMatches, this._options.pollMatchesInterval );
+        clearInterval(this._pollMatchesIntervalHandle);
+        this._pollMatchesIntervalHandle = setInterval( _pollMatches, this._options.pollMatchesInterval );
       }
 
       if( options.hasOwnProperty( 'eventsDetailLevel' ) ) {


### PR DESCRIPTION
Setting a different polling interval in the setOptions command creates a new polling interval without clearing the old one, so if you were polling once every 10 seconds, and change to once every 20 seconds, you will get both intervals running in parallel, thus making 3 calls every 20 seconds.
