### PR TITLE
important to make onsubmit return false or page will reload

### DIFF
--- a/lib/glasslab-sdk.js
+++ b/lib/glasslab-sdk.js
@@ -1146,7 +1146,6 @@ either expressed or implied, of the FreeBSD Project.
       strVar += "    background-color: #67cada;";
       strVar += "    color: white;";
       strVar += "}";
-      strVar += "";
       strVar += "#gl-sign-in {";
       strVar += "    width: 300px;";
       strVar += "    height: 200px;";
@@ -1157,24 +1156,29 @@ either expressed or implied, of the FreeBSD Project.
       strVar += "<\/style>";
       strVar += "<div id=\"gl-sign-in\"> ";
       strVar += "<b id=\"gl-sign-in-text\"> Sign In: <\/b>";
-      strVar += "<form class=\"gl-form-input\">";
+      strVar += "<form id=\"gl-login-form\" class=\"gl-form-input\">";
       strVar += "<input id=\"gl-username\" type=\"text\" placeholder=\"Screen Name\">";
       strVar += "<input id=\"gl-password\" type=\"password\" placeholder=\"Password\">";
       strVar += "<input id=\"gl-login\" type=\"submit\"> ";
       strVar += "<\/form>";
       strVar += "<\/div>";
 
-      setTimeout(function () {
-          document.getElementById( "gl-login" ).addEventListener( "click", function() {
-              var username = document.getElementById( 'gl-username' ).value;
-              var password = document.getElementById( 'gl-password' ).value;
-              GlassLabSDK.login( username, password, success, fail );
-          });
-      }, 1000);
+      var intervalCheckRender = window.setInterval(function () {
+        var form = document.getElementById("gl-login-form");
+        if (form) {
+          window.clearInterval(intervalCheckRender);
+          form.onsubmit = function () {
+            var username = document.getElementById( 'gl-username' ).value;
+            var password = document.getElementById( 'gl-password' ).value;
+            GlassLabSDK.login(username, password, success, fail);
+            return false;
+          };
+          document.getElementById("gl-username").focus();
+        }
+      }, 10);
 
       return strVar;
   };
-
 
   function defaultSuccessCallback( callback, data ) {
     if( callback && isFunction(callback)) {


### PR DESCRIPTION
former code added a click listener to the submit element and kicked off a glasslab login.  A couple of problems here:
1. Pressing ENTER with focus on either input element will automatically submit the form, which is assumed to be a GET of the current page, i.e. it will just reload the current page without logging in
2. Clicking the submit button will cause the listener to react, but it will ALSO submit the form, which reloads the page, generally before the login completes.

Instead I took the approach to set the onsubmit function of the form, to do what we want and then return false, this way it works the same for keyboard or mouse entry.

Also, instead of waiting 1 second and hoping that the form has been rendered by then, I kick off an interval to watch for the form to be rendered, and focus the username element as soon as the element is available.
